### PR TITLE
Corrected typo in API params (leftovers) in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ An alternate way to do Step 2 would be to use PHP arrays and programmatically ge
         $result = $client->getCheckoutSession($checkoutSessionId);
         if ($result['status'] === 200) {
             $response = json_decode($result['response'], true);
-            $checkoutSessionState = $response['statusDetails']['state'];
+            $checkoutSessionState = $response['statusDetail']['state'];
             $chargeId = $response['chargeId'];
             $chargePermissionId = $response['chargePermissionId'];
 
@@ -378,7 +378,7 @@ An alternate way to do Step 2 would be to use PHP arrays and programmatically ge
     );
 
     $payload = array(
-       'paymentDetails' => array(
+       'paymentDetail' => array(
             'paymentIntent' => 'Authorize',
             'canHandlePendingAuthorization' => false,
             'chargeAmount' => array(


### PR DESCRIPTION
*Issue #, if available:*
wrong params in API request and responses in README example

*Description of changes:*
Corrected typo in API params (leftovers) in API examples

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
